### PR TITLE
adding readme section on networking to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ expected outcome :
 
 You can now access your pihole homepage using `YourNasIP:8888/admin` url
 
-
+### Networking ###
+It should be **strongly** noted that this docker installation **only supports host network drivers** (https://docs.docker.com/engine/network/drivers/host/). Any port bindings via `-p` will get ignored and will not work. You need to make sure to use `--network host` when starting your containers. Also ensure that no existing services are already running on the port you want to use for your container. 
 
 


### PR DESCRIPTION
I spent an hour or two on trying to bind ports only to discover that compose files for portainer (which I was not using as i m fine with command line) are using host network driver (apparently the only one really functional). I think this section in README can help others in the future 